### PR TITLE
Feature: add support for empty interpolant

### DIFF
--- a/source/module_base/cubic_spline.cpp
+++ b/source/module_base/cubic_spline.cpp
@@ -56,6 +56,18 @@ CubicSpline::CubicSpline(
 }
 
 
+CubicSpline::CubicSpline(int n, const double* x)
+    : n_spline_(0), n_(n), xmin_(x[0]), xmax_(x[n - 1]), x_(x, x + n)
+{
+}
+
+
+CubicSpline::CubicSpline(int n, double x0, double dx)
+    : n_spline_(0), n_(n), xmin_(x0), xmax_(x0 + (n - 1) * dx), dx_(dx)
+{
+}
+
+
 void CubicSpline::add(
     const double* y,
     const BoundaryCondition& bc_start,

--- a/source/module_base/cubic_spline.h
+++ b/source/module_base/cubic_spline.h
@@ -81,6 +81,13 @@ namespace ModuleBase
  *      cubspl5.add(y4, {}, {CubicSpline::BoundaryType::second_deriv, 2.0});
  *      cubspl5.add(y5);
  *
+ *      // alternative, one may start with an empty object with knots only:
+ *      // CubicSpline cubspl5(n, x);
+ *      // cubspl5.reserve(5);
+ *      // cubspl5.add(y);
+ *      // cubspl5.add(y2);
+ *      // ...
+ *
  *      // evaluates the five interpolants simultaneously at a single place
  *      cubspl5.multi_eval(x_interp, y_interp)
  *
@@ -223,7 +230,35 @@ public:
 
 
     /**
-     * @brief Add an interpolant that shares the same knots.
+     * @brief Builds an empty object with specified knots only.
+     *
+     * An object of this class can hold multiple interpolants with the same knots.
+     * This constructor allows the user to initialize the object with knots only,
+     * so that interpolants can be added later.
+     * 
+     * @param[in]   n               number of knots
+     * @param[in]   x               x coordinates of data points
+     *                              ("knots", must be strictly increasing)
+     *
+     */
+    CubicSpline(int n, const double* x);
+
+    /**
+     * @brief Builds an empty object with specified knots only.
+     *
+     * An object of this class can hold multiple interpolants with the same knots.
+     * This constructor allows the user to initialize the object with knots only,
+     * so that interpolants can be added later.
+     *
+     * @param[in]   n               number of knots
+     * @param[in]   x0              x coordinate of the first data point (first knot)
+     * @param[in]   dx              spacing between knots (must be positive)
+     *
+     */
+    CubicSpline(int n, double x0, double dx);
+
+    /**
+     * @brief Adds an interpolant that shares the same knots.
      *
      * An object of this class can hold multiple interpolants with the same knots.
      * Once constructed, more interpolants sharing the same knots can be added by
@@ -335,6 +370,9 @@ public:
 
     /// last knot
     double xmax() const { return xmax_; }
+
+    /// number of interpolants held by this object
+    int n_spline() const { return n_spline_; }
 
 
 private:

--- a/source/module_base/test/cubic_spline_test.cpp
+++ b/source/module_base/test/cubic_spline_test.cpp
@@ -270,18 +270,18 @@ TEST_F(CubicSplineTest, MultiEval)
 
     std::for_each(x_, x_ + n, [&](double& x) { x = xmin + (&x - x_) * dx; });
 
-    std::transform(x_, x_ + n, y_, [this](double x) { return f_[0][0](x); });
-    CubicSpline cubspl(n, xmin, dx, y_,
-                       {BoundaryType::first_deriv, f_[0][1](xmin)},
-                       {BoundaryType::first_deriv, f_[0][1](xmax)});
-
+    // empty interpolant with specified knots
+    CubicSpline cubspl(n, xmin, dx);
     cubspl.reserve(f_.size());
-    for (size_t i = 1; i < f_.size(); ++i)
+
+    for (size_t i = 0; i < f_.size(); ++i)
     {
         std::transform(x_, x_ + n, y_, [this, i](double x) { return f_[i][0](x); });
         cubspl.add(y_, {BoundaryType::first_deriv, f_[i][1](xmin)},
                        {BoundaryType::first_deriv, f_[i][1](xmax)});
     }
+
+    EXPECT_EQ(cubspl.n_spline(), f_.size());
 
     std::vector<std::vector<double>> err_bound(f_.size(), std::vector<double>(3));
     for (size_t i = 0; i < f_.size(); ++i)


### PR DESCRIPTION
This PR enables CubicSpline to be constructed with knots only (i.e., an empty interpolant)
